### PR TITLE
Fix Col offset

### DIFF
--- a/src/components/Col/Col.test.tsx
+++ b/src/components/Col/Col.test.tsx
@@ -31,10 +31,4 @@ describe('Col', () => {
 
     expect(container.firstChild).toMatchSnapshot();
   });
-
-  it.each(sizes)('should render with offset styles for media %s', (size) => {
-    const { container } = render(<Col offset={size}>Col</Col>);
-
-    expect(container.firstChild).toMatchSnapshot();
-  });
 });

--- a/src/components/Col/Col.test.tsx
+++ b/src/components/Col/Col.test.tsx
@@ -43,4 +43,15 @@ describe('Col', () => {
 
     expect(container.firstChild).toMatchSnapshot();
   });
+
+  it('should handle negative offset styles', () => {
+    const offsets = { xs: -1, lg: 9 } as Record<Breakpoints, number>;
+    const { container } = render(
+      <Col md={8} offset={offsets}>
+        Col
+      </Col>
+    );
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
 });

--- a/src/components/Col/Col.test.tsx
+++ b/src/components/Col/Col.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render } from '@testing-library/react';
 
 import { Col } from './Col';
+import { Breakpoints } from '../../types/types';
 
 describe('Col', () => {
   it('should render with default styles', () => {
@@ -28,6 +29,17 @@ describe('Col', () => {
 
   it.each(sizes)('should render with offset styles', (size) => {
     const { container } = render(<Col offset={size}>Col</Col>);
+
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it('should handle 0 offset styles', () => {
+    const offsets = { xs: 0, lg: 9 } as Record<Breakpoints, number>;
+    const { container } = render(
+      <Col md={8} offset={offsets}>
+        Col
+      </Col>
+    );
 
     expect(container.firstChild).toMatchSnapshot();
   });

--- a/src/components/Col/Col.tsx
+++ b/src/components/Col/Col.tsx
@@ -59,9 +59,9 @@ const offsetStyle = ({ theme, offset }: Types.StyleProps & Types.ColProps) =>
       offset[breakpoint] &&
       css`
         ${media(breakpoint)} {
-          margin-left: ${(offset[breakpoint] /
-            config(theme).columns[breakpoint]) *
-          100}%;
+          margin-left: ${offset[breakpoint] >= 0
+            ? (offset[breakpoint] / config(theme).columns[breakpoint]) * 100
+            : 0}%;
         }
       `
   );

--- a/src/components/Col/Col.tsx
+++ b/src/components/Col/Col.tsx
@@ -54,14 +54,14 @@ const sizeStyle = (props: Types.StyleProps & Types.ColProps) => {
 const offsetStyle = ({ theme, offset }: Types.StyleProps & Types.ColProps) =>
   offset &&
   typeof offset === 'object' &&
-  constants.BREAKPOINTS.map(
+  constants.BREAKPOINTS.filter((breakpoint) => offset[breakpoint]).map(
     (breakpoint) =>
       offset[breakpoint] &&
       css`
         ${media(breakpoint)} {
-          margin-left: ${offset[breakpoint] > 0
-            ? (offset[breakpoint] / config(theme).columns[breakpoint]) * 100
-            : 0}%;
+          margin-left: ${(offset[breakpoint] /
+            config(theme).columns[breakpoint]) *
+          100}%;
         }
       `
   );

--- a/src/components/Col/__snapshots__/Col.test.tsx.snap
+++ b/src/components/Col/__snapshots__/Col.test.tsx.snap
@@ -136,6 +136,154 @@ exports[`Col should handle 0 offset styles 1`] = `
 </div>
 `;
 
+exports[`Col should handle negative offset styles 1`] = `
+.grid-0 {
+  position: relative;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+}
+
+@media (min-width: 1em) {
+  .grid-0 {
+    padding-left: 0.9375rem;
+    padding-right: 0.9375rem;
+  }
+}
+
+@media (min-width: 33.75em) {
+  .grid-0 {
+    padding-left: 0.9375rem;
+    padding-right: 0.9375rem;
+  }
+}
+
+@media (min-width: 48em) {
+  .grid-0 {
+    padding-left: 0.9375rem;
+    padding-right: 0.9375rem;
+  }
+}
+
+@media (min-width: 64em) {
+  .grid-0 {
+    padding-left: 0.9375rem;
+    padding-right: 0.9375rem;
+  }
+}
+
+@media (min-width: 71.25em) {
+  .grid-0 {
+    padding-left: 0.9375rem;
+    padding-right: 0.9375rem;
+  }
+}
+
+@media (min-width: 48em) {
+  .grid-0 {
+    -webkit-flex: 0 0 66.66666666666666%;
+    -ms-flex: 0 0 66.66666666666666%;
+    flex: 0 0 66.66666666666666%;
+    max-width: 66.66666666666666%;
+  }
+}
+
+@media (min-width: 1em) {
+  .grid-0 {
+    margin-left: 0%;
+  }
+}
+
+@media (min-width: 64em) {
+  .grid-0 {
+    margin-left: 75%;
+  }
+}
+
+.emotion-0 {
+  position: relative;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+}
+
+@media (min-width: 1em) {
+  .emotion-0 {
+    padding-left: 0.9375rem;
+    padding-right: 0.9375rem;
+  }
+}
+
+@media (min-width: 33.75em) {
+  .emotion-0 {
+    padding-left: 0.9375rem;
+    padding-right: 0.9375rem;
+  }
+}
+
+@media (min-width: 48em) {
+  .emotion-0 {
+    padding-left: 0.9375rem;
+    padding-right: 0.9375rem;
+  }
+}
+
+@media (min-width: 64em) {
+  .emotion-0 {
+    padding-left: 0.9375rem;
+    padding-right: 0.9375rem;
+  }
+}
+
+@media (min-width: 71.25em) {
+  .emotion-0 {
+    padding-left: 0.9375rem;
+    padding-right: 0.9375rem;
+  }
+}
+
+@media (min-width: 48em) {
+  .emotion-0 {
+    -webkit-flex: 0 0 66.66666666666666%;
+    -ms-flex: 0 0 66.66666666666666%;
+    flex: 0 0 66.66666666666666%;
+    max-width: 66.66666666666666%;
+  }
+}
+
+@media (min-width: 1em) {
+  .emotion-0 {
+    margin-left: 0%;
+  }
+}
+
+@media (min-width: 64em) {
+  .emotion-0 {
+    margin-left: 75%;
+  }
+}
+
+<div
+  class="emotion-0 emotion-1"
+>
+  Col
+</div>
+`;
+
 exports[`Col should render with default styles 1`] = `
 .grid-0 {
   position: relative;

--- a/src/components/Col/__snapshots__/Col.test.tsx.snap
+++ b/src/components/Col/__snapshots__/Col.test.tsx.snap
@@ -1,5 +1,141 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Col should handle 0 offset styles 1`] = `
+.grid-0 {
+  position: relative;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+}
+
+@media (min-width: 1em) {
+  .grid-0 {
+    padding-left: 0.9375rem;
+    padding-right: 0.9375rem;
+  }
+}
+
+@media (min-width: 33.75em) {
+  .grid-0 {
+    padding-left: 0.9375rem;
+    padding-right: 0.9375rem;
+  }
+}
+
+@media (min-width: 48em) {
+  .grid-0 {
+    padding-left: 0.9375rem;
+    padding-right: 0.9375rem;
+  }
+}
+
+@media (min-width: 64em) {
+  .grid-0 {
+    padding-left: 0.9375rem;
+    padding-right: 0.9375rem;
+  }
+}
+
+@media (min-width: 71.25em) {
+  .grid-0 {
+    padding-left: 0.9375rem;
+    padding-right: 0.9375rem;
+  }
+}
+
+@media (min-width: 48em) {
+  .grid-0 {
+    -webkit-flex: 0 0 66.66666666666666%;
+    -ms-flex: 0 0 66.66666666666666%;
+    flex: 0 0 66.66666666666666%;
+    max-width: 66.66666666666666%;
+  }
+}
+
+@media (min-width: 64em) {
+  .grid-0 {
+    margin-left: 75%;
+  }
+}
+
+.emotion-0 {
+  position: relative;
+  -webkit-flex-basis: 0;
+  -ms-flex-preferred-size: 0;
+  flex-basis: 0;
+  -webkit-box-flex: 1;
+  -webkit-flex-grow: 1;
+  -ms-flex-positive: 1;
+  flex-grow: 1;
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+}
+
+@media (min-width: 1em) {
+  .emotion-0 {
+    padding-left: 0.9375rem;
+    padding-right: 0.9375rem;
+  }
+}
+
+@media (min-width: 33.75em) {
+  .emotion-0 {
+    padding-left: 0.9375rem;
+    padding-right: 0.9375rem;
+  }
+}
+
+@media (min-width: 48em) {
+  .emotion-0 {
+    padding-left: 0.9375rem;
+    padding-right: 0.9375rem;
+  }
+}
+
+@media (min-width: 64em) {
+  .emotion-0 {
+    padding-left: 0.9375rem;
+    padding-right: 0.9375rem;
+  }
+}
+
+@media (min-width: 71.25em) {
+  .emotion-0 {
+    padding-left: 0.9375rem;
+    padding-right: 0.9375rem;
+  }
+}
+
+@media (min-width: 48em) {
+  .emotion-0 {
+    -webkit-flex: 0 0 66.66666666666666%;
+    -ms-flex: 0 0 66.66666666666666%;
+    flex: 0 0 66.66666666666666%;
+    max-width: 66.66666666666666%;
+  }
+}
+
+@media (min-width: 64em) {
+  .emotion-0 {
+    margin-left: 75%;
+  }
+}
+
+<div
+  class="emotion-0 emotion-1"
+>
+  Col
+</div>
+`;
+
 exports[`Col should render with default styles 1`] = `
 .grid-0 {
   position: relative;


### PR DESCRIPTION
Hi, 

I notice a possible bug on your repository regarding an edge case of the offset col. If you set the offset of a smaller breakpoint to 0 and a larger breakpoint to a number larger than 0, then the offset will not work:

![image](https://user-images.githubusercontent.com/25157901/112847797-ce37b080-907d-11eb-9fef-223f4a4e9ad3.png)

I believe that the expected behavior was:

![image](https://user-images.githubusercontent.com/25157901/112847892-e7406180-907d-11eb-81f9-b73321e4b93c.png)

So, I am proposing a change in the code so that this won't happen:

![image](https://user-images.githubusercontent.com/25157901/112848071-0fc85b80-907e-11eb-977e-fafe1db63623.png)

Please note that I think that the best way to avoid this is not setting any value to the breakpoints that you don't want any offset: `offset={{ lg: 9 }}` instead of:  `offset={{ md: 0, lg: 9 }}`. But I think that this could be useful in the off chance that someone does sets the offset to 0.
